### PR TITLE
feat: add snippets for using service account access token

### DIFF
--- a/admin/src/main/java/com/google/firebase/example/FirebaseAuthSnippets.java
+++ b/admin/src/main/java/com/google/firebase/example/FirebaseAuthSnippets.java
@@ -15,12 +15,15 @@
  */
 package com.google.firebase.example;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.auth.*;
 import com.google.firebase.auth.UserRecord.CreateRequest;
 import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -282,6 +285,21 @@ public class FirebaseAuthSnippets {
     userData.put("revokeTime", revocationSecond);
     ref.setValueAsync(userData).get();
     // [END save_revocation_in_db]
-    
+  }
+
+  public static String getServiceAccountAccessToken() throws IOException {
+    // https://firebase.google.com/docs/reference/dynamic-links/analytics#api_authorization
+    // [START get_service_account_tokens]
+    FileInputStream serviceAccount = new FileInputStream("path/to/serviceAccountKey.json");
+    GoogleCredentials credentials = GoogleCredentials.fromStream(serviceAccount);
+    credentials.refresh();
+    String accessToken = credentials.getAccessToken().getTokenValue();
+    // [START_EXCLUDE]
+    long expirationTime = credentials.getAccessToken().getExpirationTime().getTime();
+    // Attach accessToken to HTTPS request in the "Authorization: Bearer" header
+    // After expirationTime, you must generate a new access token
+    // [END_EXCLUDE]
+    return accessToken;
+    // [END get_service_account_tokens]
   }
 }

--- a/admin/src/main/java/com/google/firebase/example/FirebaseMessagingSnippets.java
+++ b/admin/src/main/java/com/google/firebase/example/FirebaseMessagingSnippets.java
@@ -27,10 +27,20 @@ import com.google.firebase.messaging.Notification;
 import com.google.firebase.messaging.TopicManagementResponse;
 import com.google.firebase.messaging.WebpushConfig;
 import com.google.firebase.messaging.WebpushNotification;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.google.firebase.example.FirebaseAuthSnippets.getServiceAccountAccessToken;
+
 public class FirebaseMessagingSnippets {
+
+  private static final String PROJECT_ID = "<YOUR-PROJECT-ID>";
+  private static final String BASE_URL = "https://fcm.googleapis.com";
+  private static final String FCM_SEND_ENDPOINT = "/v1/projects/" + PROJECT_ID + "/messages:send";
 
   public void sendToToken() throws Exception {
     // [START send_to_token]
@@ -226,5 +236,15 @@ public class FirebaseMessagingSnippets {
     // for the contents of response.
     System.out.println(response.getSuccessCount() + " tokens were unsubscribed successfully");
     // [END unsubscribe]
+  }
+
+  private static HttpURLConnection getConnection() throws IOException {
+    // [START use_access_token]
+    URL url = new URL(BASE_URL + FCM_SEND_ENDPOINT);
+    HttpURLConnection httpURLConnection = (HttpURLConnection) url.openConnection();
+    httpURLConnection.setRequestProperty("Authorization", "Bearer " + getServiceAccountAccessToken());
+    httpURLConnection.setRequestProperty("Content-Type", "application/json; UTF-8");
+    return httpURLConnection;
+    // [END use_access_token]
   }
 }

--- a/admin/src/main/java/com/google/firebase/example/Main.java
+++ b/admin/src/main/java/com/google/firebase/example/Main.java
@@ -22,22 +22,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 public class Main {
-
-    public void getServiceAccountAccessToken() throws IOException {
-        // https://firebase.google.com/docs/reference/dynamic-links/analytics#api_authorization
-        // [START get_service_account_tokens]
-        FileInputStream serviceAccount = new FileInputStream("path/to/serviceAccountKey.json");
-        GoogleCredentials credentials = GoogleCredentials.fromStream(serviceAccount);
-        credentials.refresh();
-        String accessToken = credentials.getAccessToken().getTokenValue();
-        long expirationTime = credentials.getAccessToken().getExpirationTime().getTime();
-        // Attach accessToken to HTTPS request in the
-        //   "Authorization: Bearer" header
-        // After expirationTime, you must generate a new access
-        //   token
-        // [END get_service_account_tokens]
-    }
-
     public static void main(String[] args) {
         // write your code here
     }


### PR DESCRIPTION
Add snippet for using service account access token

- Move snippet for generating service account access token to Auth snippets.
- Add snippet for using service account access token in an FCM request without Admin SDK.